### PR TITLE
chore: replace `@atproto/api` with `@atcute/client` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "typescript-eslint": "^8.15.0"
   },
   "dependencies": {
-    "@atproto/api": "^0.13.16",
+    "@atcute/client": "^2.0.7",
     "@skyware/bot": "^0.3.7",
     "@skyware/jetstream": "^0.2.0",
     "@skyware/labeler": "^0.1.13",

--- a/src/set-labels.ts
+++ b/src/set-labels.ts
@@ -1,4 +1,4 @@
-import { type ComAtprotoLabelDefs } from '@atproto/api';
+import { type ComAtprotoLabelDefs } from '@atcute/client/lexicons';
 import { type LoginCredentials, setLabelerLabelDefinitions } from '@skyware/labeler/scripts';
 
 import { BSKY_IDENTIFIER, BSKY_PASSWORD } from './config.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
-import { LabelValueDefinitionStrings } from '@atproto/api/dist/client/types/com/atproto/label/defs.js';
+import { type ComAtprotoLabelDefs } from '@atcute/client/lexicons';
 
 export interface Label {
   rkey: string;
   identifier: string;
-  locales: LabelValueDefinitionStrings[];
+  locales: ComAtprotoLabelDefs.LabelValueDefinitionStrings[];
 }


### PR DESCRIPTION
Hello, this PR replaces types (there were only two places) from `@atproto/api` with the ones from `@atcute/client`, and removes `@atproto/api` package.

Reading this post (https://bsky.app/profile/aliceweb.xyz/post/3l5kqas6n7h2o) made me want to create this PR 🙂 